### PR TITLE
[Bug] Super/Meta modifier mapping in uinput_modifiers_to_ak_map

### DIFF
--- a/lib/autokey/uinput_interface.py
+++ b/lib/autokey/uinput_interface.py
@@ -132,8 +132,8 @@ class UInputInterface(threading.Thread, MouseReadInterface, AbstractSysInterface
         "KEY_LEFTALT": Key.LEFTALT,
         "KEY_RIGHTALT": Key.RIGHTALT,
 
-        "KEY_LEFTMETA": Key.LEFTMETA,
-        "KEY_RIGHTMETA": Key.RIGHTMETA,
+        "KEY_LEFTMETA": Key.LEFTSUPER,
+        "KEY_RIGHTMETA": Key.RIGHTSUPER,
 
     }
 


### PR DESCRIPTION
Map `KEY_LEFTMETA` → `Key.LEFTSUPER` and `KEY_RIGHTMETA` → `Key.RIGHTSUPER` to match how hotkeys are defined.

Fixes #41
Related: #10