### PR TITLE
[RFE] Sway desktop support for Wayland

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -32,7 +32,8 @@ Depends: imagemagick,
          xautomation,
          ${misc:Depends},
          ${python3:Depends}
-Recommends: wl-clipboard
+Recommends: wl-clipboard,
+            gir1.2-libxfce4windowing-0.0
 Description: desktop automation utility - common data
  AutoKey is a desktop automation utility for Linux, Wayland, and X11. It allows 
  the automation of virtually any task by responding to typed abbreviations and

--- a/fedora/autokey.spec
+++ b/fedora/autokey.spec
@@ -24,15 +24,16 @@ the full flexibility and power of the Python language.
 
 %package common
 Summary:	Desktop automation utility - common data
-Requires:	gnome-extensions-app
 Requires:	python3-dbus
 Requires:	python3-evdev
 Requires:	python3-pyudev
 Requires:	python3-pydbus
 Requires:	ImageMagick
+Recommends:	gnome-extensions-app
 Recommends:	wmctrl
 Recommends:	xautomation
 Recommends:	wl-clipboard
+Recommends:	libxfce4windowing
 Provides:	autokey = %{version}-%{release}
 %description common
 This package contains the common data shared between the various front ends.

--- a/lib/autokey/common.py
+++ b/lib/autokey/common.py
@@ -25,8 +25,19 @@ XDG_CACHE_HOME = os.environ.get('XDG_CACHE_HOME', os.path.expanduser('~/.cache')
 XDG_DATA_HOME = os.environ.get('XDG_DATA_HOME', os.path.expanduser("~/.local/share"))
 SESSION_TYPE = os.environ.get("XDG_SESSION_TYPE")
 DESKTOP = os.environ.get('XDG_CURRENT_DESKTOP')
-if DESKTOP and DESKTOP.lower() in ('kde', 'plasma'):
-    DESKTOP = 'KDE'
+if DESKTOP:
+    _desktop_lower = DESKTOP.lower()
+    if _desktop_lower in ('kde', 'plasma'):
+        DESKTOP = 'KDE'
+    # Budgie before GNOME: Budgie sets XDG_CURRENT_DESKTOP=budgie:GNOME
+    elif 'budgie' in _desktop_lower:
+        DESKTOP = 'BUDGIE'
+    elif _desktop_lower == 'sway':
+        DESKTOP = 'SWAY'
+    elif 'gnome' in _desktop_lower:
+        DESKTOP = 'GNOME'
+
+WLROOTS_DESKTOPS = ('BUDGIE', 'SWAY')
 
 CONFIG_DIR = os.path.join(XDG_CONFIG_HOME, "autokey")
 RUN_DIR = os.path.join(os.environ.get('XDG_RUNTIME_DIR', XDG_CACHE_HOME), "autokey")

--- a/lib/autokey/iomediator/iomediator.py
+++ b/lib/autokey/iomediator/iomediator.py
@@ -24,6 +24,8 @@ from autokey.configmanager.configmanager import ConfigManager
 from autokey.configmanager.configmanager_constants import INTERFACE_TYPE
 if common.DESKTOP == 'KDE':
     from autokey.kde_interface import KdeWindowInterface
+elif common.DESKTOP in common.WLROOTS_DESKTOPS:
+    from autokey.wlroots_interface import WlrootsWindowInterface
 else:
     from autokey.gnome_interface import GnomeExtensionWindowInterface
 from autokey.sys_interface.clipboard import Clipboard
@@ -77,6 +79,9 @@ class IoMediator(threading.Thread):
             if common.DESKTOP == 'KDE':
                 logger.debug("Using kde window interface")
                 self.windowInterface = KdeWindowInterface()
+            elif common.DESKTOP in common.WLROOTS_DESKTOPS:
+                logger.debug("Using wlroots window interface")
+                self.windowInterface = WlrootsWindowInterface()
             else:
                 logger.debug("Using gnome extension window interface")
                 self.windowInterface = GnomeExtensionWindowInterface()

--- a/lib/autokey/scripting/__init__.py
+++ b/lib/autokey/scripting/__init__.py
@@ -56,6 +56,8 @@ elif autokey.common.USED_UI_TYPE == "headless":
 if autokey.common.SESSION_TYPE == "wayland":
     if autokey.common.DESKTOP == 'KDE':
         from .window_kde import Window
+    elif autokey.common.DESKTOP in autokey.common.WLROOTS_DESKTOPS:
+        from .window_wlroots import Window
     else:
         from .window_gnome import Window
     pass

--- a/lib/autokey/scripting/window_wlroots.py
+++ b/lib/autokey/scripting/window_wlroots.py
@@ -1,0 +1,351 @@
+"""
+Desktop window management for wlroots-based Wayland compositors
+(Budgie 10/labwc, Sway, etc.) via libxfce4windowing.
+"""
+
+import re
+import time
+import socket
+from .abstract_window import AbstractWindow
+
+logger = __import__("autokey.logger").logger.get_logger(__name__)
+
+
+class Window(AbstractWindow):
+
+    def __init__(self, mediator):
+        self.mediator = mediator
+
+    def wait_for_focus(self, title, timeOut=5):
+        """
+        Wait for window with the given title to have focus
+
+        Usage: C{window.wait_for_focus(title, timeOut=5)}
+
+        If the window becomes active, returns True. Otherwise, returns False if
+        the window has not become active by the time the timeout has elapsed.
+
+        :param title: title to match against (as a regular expression)
+        :param timeOut: period (seconds) to wait before giving up
+        :rtype: boolean
+        """
+        start = time.time()
+        while time.time() - start <= timeOut:
+            for item in self.mediator.windowInterface.get_window_list():
+                if item['focus'] and re.search(rf'{title}', item['wm_title'], re.IGNORECASE):
+                    return True
+            time.sleep(0.3)
+        return False
+
+    def wait_for_exist(self, title, timeOut=5, by_hex=False):
+        """
+        Wait for window with the given title to be created
+
+        Usage: C{window.wait_for_exist(title, timeOut=5)}
+
+        If the window is in existence, returns True. Otherwise, returns False if
+        the window has not been created by the time the timeout has elapsed.
+
+        :param title: title to match against (as a regular expression)
+        :param timeOut: period (seconds) to wait before giving up
+        :param by_hex: If true, will interpret the C{title} as a hexid
+        :rtype: boolean
+        """
+        start = time.time()
+        while time.time() - start <= timeOut:
+            for item in self.mediator.windowInterface.get_window_list():
+                if (by_hex and by_hex == item['id']) or re.search(rf'{title}', item['wm_title'], re.IGNORECASE):
+                    return True
+            time.sleep(0.3)
+        return False
+
+    def activate(self, title, switchDesktop=False, matchClass=False, by_hex=False):
+        """
+        Activate the specified window, giving it input focus
+
+        Usage: C{window.activate(title, switchDesktop=False, matchClass=False)}
+
+        If switchDesktop is False (default), the window will be moved to the
+        current desktop and activated. Otherwise, switch to the window's current
+        desktop and activate it there.
+
+        :param title: window title to match against (as case-insensitive substring match)
+        :param switchDesktop: If True, switch to desktop where window resides and activate
+        :param matchClass: if True, match on the window class instead of the title
+        :param by_hex: If true, interpret the C{title} as a hexid
+        """
+        target_window = self.__get_target_window(title, matchClass, by_hex)
+        if target_window:
+            if switchDesktop:
+                self.mediator.windowInterface.switch_workspace(target_window['workspace'])
+            else:
+                wksid = self.mediator.windowInterface.get_active_desktop_index()
+                self.mediator.windowInterface.move_to_workspace(target_window['id'], wksid)
+            self.mediator.windowInterface.activate_window(target_window['id'])
+
+    def close(self, title, matchClass=False, by_hex=False):
+        """
+        Close the specified window gracefully
+
+        Usage: C{window.close(title, matchClass=False)}
+
+        :param title: window title to match against (as case-insensitive substring match)
+        :param matchClass: if True, match on the window class instead of the title
+        :param by_hex: If true, interpret the C{title} as a hexid
+        """
+        target_window = self.__get_target_window(title, matchClass, by_hex)
+        if target_window:
+            self.mediator.windowInterface.close_window(target_window['id'])
+
+    def resize_move(self, title, xOrigin=-1, yOrigin=-1, width=-1, height=-1, matchClass=False, by_hex=False):
+        """
+        Resize and/or move the specified window
+
+        Usage: C{window.resize_move(title, xOrigin=-1, yOrigin=-1, width=-1, height=-1, matchClass=False)}
+
+        Leaving any of the position/dimension values as the default (-1) will cause that
+        value to be left unmodified.
+
+        Note: Window geometry is not available on all wlroots compositors under Wayland.
+
+        :param title: window title to match against (as case-insensitive substring match)
+        :param xOrigin: new x origin of the window (upper left corner)
+        :param yOrigin: new y origin of the window (upper left corner)
+        :param width: new width of the window
+        :param height: new height of the window
+        :param matchClass: if C{True}, match on the window class instead of the title
+        :param by_hex: If true, interpret the C{title} as a hexid
+        """
+        target_window = self.__get_target_window(title, matchClass, by_hex)
+        if target_window:
+            hexid = target_window['id']
+            if xOrigin == -1:
+                xOrigin = target_window['x']
+            if yOrigin == -1:
+                yOrigin = target_window['y']
+            if width == -1:
+                width = target_window['width']
+            if height == -1:
+                height = target_window['height']
+            self.mediator.windowInterface.move_resize_window(hexid, xOrigin, yOrigin, width, height)
+
+    def move_to_desktop(self, title, deskNum, matchClass=False, by_hex=False):
+        """
+        Move window to specified desktop (workspace)
+
+        Usage: C{window.move_to_desktop(title, deskNum, matchClass=False, by_hex=False)}
+
+        :param title: window title to match against (as case-insensitive substring match)
+        :param deskNum: the number of the desktop (workspace) to which to move this window (note: zero based)
+        :param matchClass: if C{True}, match on the window class instead of the title
+        :param by_hex: If true, interpret the C{title} as a hexid
+        """
+        target_window = self.__get_target_window(title, matchClass, by_hex)
+        if target_window:
+            self.mediator.windowInterface.move_to_workspace(target_window['id'], deskNum)
+
+    def switch_desktop(self, deskNum):
+        """
+        Switch to the specified desktop (workspace)
+
+        Usage: C{window.switch_desktop(deskNum)}
+
+        :param deskNum: desktop to switch to (note: zero based)
+        """
+        self.mediator.windowInterface.switch_workspace(deskNum)
+
+    def set_property(self, title, action, prop, matchClass=False, by_hex=False):
+        """
+        Set a property on the given window using the specified action
+
+        Usage: C{window.set_property(title, action, prop, matchClass=False, by_hex=False)}
+
+        Allowable actions: add, remove, toggle
+
+        Properties: sticky, maximized_vert, maximized_horz, fullscreen, above
+
+        :param title: window title to match against (as case-insensitive substring match)
+        :param action: one of the actions listed above
+        :param prop: one of the properties listed above
+        :param matchClass: if True, match on the window class instead of the title
+        :param by_hex: If true, will interpret the C{title} as a hexid
+        """
+        target_window = self.__get_target_window(title, matchClass, by_hex)
+        if not target_window:
+            return
+
+        wid = target_window['id']
+
+        if prop == 'sticky':
+            if action == 'toggle':
+                logger.error('Current sticky state unknown, "toggle" action is not supported in window.set_property()')
+            elif action == 'add':
+                self.mediator.windowInterface.stick_window(wid)
+            elif action == 'remove':
+                self.mediator.windowInterface.unstick_window(wid)
+            else:
+                logger.error(f'Unknown action "{action}" in window.set_property()')
+        elif prop in ('maximized_vert', 'maximized_horz'):
+            direction = 2 if prop == 'maximized_vert' else 1
+            if action == 'add':
+                self.mediator.windowInterface.maximize_window(wid, direction)
+            elif action == 'remove':
+                self.mediator.windowInterface.unmaximize_window(wid, direction)
+            elif action == 'toggle':
+                properties = self.mediator.windowInterface.get_properties(wid)
+                if properties.get('is_maximized', False):
+                    self.mediator.windowInterface.unmaximize_window(wid, direction)
+                else:
+                    self.mediator.windowInterface.maximize_window(wid, direction)
+            else:
+                logger.error(f'Unknown action "{action}" in window.set_property()')
+        elif prop == 'fullscreen':
+            if action == 'add':
+                self.mediator.windowInterface.make_fullscreen_window(wid)
+            elif action == 'remove':
+                self.mediator.windowInterface.unmake_fullscreen_window(wid)
+            elif action == 'toggle':
+                properties = self.mediator.windowInterface.get_properties(wid)
+                if properties.get('is_fullscreen', False):
+                    self.mediator.windowInterface.unmake_fullscreen_window(wid)
+                else:
+                    self.mediator.windowInterface.make_fullscreen_window(wid)
+            else:
+                logger.error(f'Unknown action "{action}" in window.set_property()')
+        elif prop == 'above':
+            if action == 'add':
+                self.mediator.windowInterface.make_above_window(wid)
+            elif action == 'remove':
+                self.mediator.windowInterface.unmake_above_window(wid)
+            elif action == 'toggle':
+                properties = self.mediator.windowInterface.get_properties(wid)
+                if properties.get('is_above', False):
+                    self.mediator.windowInterface.unmake_above_window(wid)
+                else:
+                    self.mediator.windowInterface.make_above_window(wid)
+            else:
+                logger.error(f'Unknown action "{action}" in window.set_property()')
+        else:
+            logger.error(f'Unknown or unimplemented property "{prop}" in window.set_property()')
+
+    def get_active_geometry(self):
+        """
+        Get the geometry of the currently active window.
+
+        Note: Window geometry may not be available on all wlroots compositors.
+
+        Usage: C{window.get_active_geometry()}
+
+        :return: a 4-tuple containing the x-origin, y-origin, width and height of the window (in pixels)
+        :rtype: C{tuple(int, int, int, int)}
+        """
+        return self.get_window_geometry(":ACTIVE:")
+
+    def get_active_title(self):
+        """
+        Get the visible title of the currently active window
+
+        Usage: C{window.get_active_title()}
+
+        :return: the visible title of the currently active window
+        :rtype: C{str}
+        """
+        return self.mediator.windowInterface.get_window_title()
+
+    def get_active_class(self):
+        """
+        Get the class (app_id) of the currently active window
+
+        Usage: C{window.get_active_class()}
+
+        :return: the class of the currently active window
+        :rtype: C{str}
+        """
+        return self.mediator.windowInterface.get_window_class()
+
+    def center_window(self, title=":ACTIVE:", win_width=None, win_height=None, matchClass=False, by_hex=False):
+        """
+        Centers the active (or window selected by title) window.
+
+        :param title: Title of the window to center (defaults to using the active window)
+        :param win_width: Width of the centered window, defaults to screenx/3. Use -1 to center without size change.
+        :param win_height: Height of the centered window, defaults to screeny/3. Use -1 to center without size change.
+        :param matchClass: if True, match on the window class instead of the title
+        :param by_hex: If true, interpret the C{title} as a hexid
+        """
+        (screen_width, screen_height) = self.mediator.windowInterface.get_screen_size()
+        try:
+            target_window = self.__get_target_window(title, matchClass, by_hex)
+            if target_window:
+                if win_width == -1:
+                    win_width = target_window['width']
+                elif not win_width:
+                    win_width = screen_width // 3
+                if win_height == -1:
+                    win_height = target_window['height']
+                elif not win_height:
+                    win_height = screen_height // 3
+                x = (screen_width - win_width) // 2
+                y = (screen_height - win_height) // 2
+                self.resize_move(title, x, y, win_width, win_height, matchClass=matchClass, by_hex=by_hex)
+        except Exception as e:
+            logger.error('window.center_window() script API unable to get a valid numeric screen resolution')
+
+    def get_window_list(self, filter_desktop=-1):
+        """
+        Returns a list of windows matching an optional desktop filter.
+
+        Each list item consists of: C{[hexid, desktop, hostname, title]}
+
+        :param filter_desktop: Filter by desktop number (note: zero based). -1 means all desktops.
+        :return: C{[[hexid1, desktop1, hostname1, title1], ...]} Returns C{[]} if no windows are found.
+        """
+        output_list = []
+        for item in self.mediator.windowInterface.get_window_list():
+            window = (
+                item['id'],
+                item['workspace'],
+                socket.gethostname(),
+                item['wm_title']
+            )
+            if filter_desktop != -1:
+                if item['workspace'] == filter_desktop:
+                    output_list.append(window)
+            else:
+                output_list.append(window)
+        return output_list
+
+    def get_window_geometry(self, title, matchClass=False, by_hex=False):
+        """
+        Returns the window geometry of the given window title.
+
+        Note: Window geometry may not be available on all wlroots compositors.
+
+        :param title: Window title to match.  Use ":ACTIVE:" for the focused window.
+        :param matchClass: if True, match on the window class instead of the title
+        :param by_hex: If true, interpret the C{title} as a hexid
+        :return: C{(offsetx, offsety, sizex, sizey)} or None
+        """
+        target_window = self.__get_target_window(title, matchClass, by_hex)
+        if target_window:
+            return (target_window['x'], target_window['y'], target_window['width'], target_window['height'])
+        return None
+
+    def __get_target_window(self, title, matchClass, by_hex):
+        if by_hex and matchClass:
+            logger.warning('window API: both by_hex and matchClass are set True, ignoring matchClass and continuing')
+
+        for win in self.mediator.windowInterface.get_window_list():
+            if by_hex:
+                if win['id'] == title:
+                    return win
+            else:
+                if matchClass:
+                    if re.search(rf'{title}', win['wm_class'], re.IGNORECASE):
+                        return win
+                else:
+                    if title == ':ACTIVE:' and win['focus']:
+                        return win
+                    elif re.search(rf'{title}', win['wm_title'], re.IGNORECASE):
+                        return win
+        return None

--- a/lib/autokey/uinput_interface.py
+++ b/lib/autokey/uinput_interface.py
@@ -54,6 +54,10 @@ import autokey.configmanager.configmanager as cm
 import autokey.configmanager.configmanager_constants as cm_constants
 if common.DESKTOP == 'KDE':
     from autokey.kde_interface import KdeMouseInterface as MouseReadInterface
+elif common.DESKTOP == 'SWAY':
+    from autokey.wlroots_interface import SwayMouseInterface as MouseReadInterface
+elif common.DESKTOP in common.WLROOTS_DESKTOPS:
+    from autokey.wlroots_interface import FallbackMouseInterface as MouseReadInterface
 else:
     from autokey.gnome_interface import GnomeMouseReadInterface as MouseReadInterface
 
@@ -442,9 +446,7 @@ class UInputInterface(threading.Thread, MouseReadInterface, AbstractSysInterface
         self.ui.write(e.EV_KEY, keycode, 0)
         self.syn_raw()
 
-    # implemented in MouseReadInterface
-    # def mouse_location(self):
-    #     raise NotImplementedError
+    # mouse_location() is provided by the MouseReadInterface mixin
 
     def relative_mouse_location(self, window=None):
         mousex,mousey = self.mouse_location()

--- a/lib/autokey/wayland_checks.py
+++ b/lib/autokey/wayland_checks.py
@@ -39,10 +39,15 @@ def waylandChecks():
             return True
 
         #  Check that we're running on a supported desktop environment
-        if os.environ['XDG_SESSION_DESKTOP'] == 'gnome' or 'GNOME_DESKTOP_SESSION_ID' in os.environ or os.environ['XDG_SESSION_DESKTOP'] == 'KDE':
-            logger.debug(f"waylandChecks() found AutoKey running under a supported desktop environment: {os.environ['XDG_SESSION_DESKTOP']}")
+        session_desktop = os.environ.get('XDG_SESSION_DESKTOP', '').lower()
+        supported = (
+            session_desktop in ('gnome', 'kde', 'sway', 'budgie', 'budgie-desktop')
+            or 'GNOME_DESKTOP_SESSION_ID' in os.environ
+        )
+        if supported:
+            logger.debug(f"waylandChecks() found AutoKey running under a supported desktop environment: {session_desktop}")
         else:
-            logger.debug(f"waylandChecks() found AutoKey running under an unsupported desktop environment: {os.environ['XDG_SESSION_DESKTOP']}, displaying popup.")
+            logger.debug(f"waylandChecks() found AutoKey running under an unsupported desktop environment: {session_desktop}, displaying popup.")
             __show_unsupported_desktop_popup()
             return False
     except Exception as e:
@@ -53,7 +58,12 @@ def waylandChecks():
     show_popup = False
 
     #  Gnome check: is the Gnome Shell extension present?
-    if os.environ['XDG_SESSION_DESKTOP'] == 'gnome' or 'GNOME_DESKTOP_SESSION_ID' in os.environ:
+    #  Budgie sets GNOME_DESKTOP_SESSION_ID but doesn't use GNOME Shell extensions
+    is_gnome = session_desktop == 'gnome' or (
+        'GNOME_DESKTOP_SESSION_ID' in os.environ
+        and session_desktop not in ('budgie', 'budgie-desktop')
+    )
+    if is_gnome:
         ext_id = 'autokey-gnome-extension@autokey'
         try:
             proc = subprocess.run(f'gnome-extensions info {ext_id}', shell=True, capture_output=True, check=True)
@@ -85,11 +95,11 @@ def waylandChecks():
 
     #  If there was a problem, throw up a popup box telling them what to do
     if show_popup:
-        #  This is Gnome-specific, other DTEs added in the future may need
-        #  different messages
         title = 'AutoKey System Configuration Needed'
-        if os.environ['XDG_SESSION_DESKTOP'] == 'KDE':
+        if session_desktop == 'kde':
             message = f'Your user id is not configured to run AutoKey under Wayland.  If this is your <b>first time</b> running AutoKey, try <b>rebooting</b> your system and starting AutoKey again.  Otherwise, try entering this two command, then rebooting:<br /><br />sudo usermod -a -G "{group}" "{user}"'
+        elif session_desktop in ('sway', 'budgie', 'budgie-desktop'):
+            message = f'Your user id is not configured to run AutoKey under Wayland.  If this is your <b>first time</b> running AutoKey, try <b>rebooting</b> your system and starting AutoKey again.  Otherwise, try entering this command, then rebooting:<br /><br />sudo usermod -a -G "{group}" "{user}"'
         else:
             message = f'Your user id is not configured to run AutoKey under Wayland.  If this is your <b>first time</b> running AutoKey, try <b>rebooting</b> your system and starting AutoKey again.  Otherwise, try entering these two commands, then rebooting:<br /><br />sudo usermod -a -G "{group}" "{user}"<br /><br />gnome-extensions install --force /usr/share/autokey/gnome-shell-extension/autokey-gnome-extension@autokey.shell-extension.zip'
         __show_popup(title, message)

--- a/lib/autokey/wlroots_interface.py
+++ b/lib/autokey/wlroots_interface.py
@@ -1,0 +1,269 @@
+import json
+import subprocess
+import threading
+
+import gi
+gi.require_version('Libxfce4windowing', '0.0')
+from gi.repository import Libxfce4windowing as Xfw
+from gi.repository import GLib
+
+from autokey import common
+from autokey.sys_interface.abstract_interface import AbstractWindowInterface, WindowInfo
+
+logger = __import__("autokey.logger").logger.get_logger(__name__)
+
+
+class WlrootsWindowInterface(AbstractWindowInterface):
+
+    def __init__(self):
+        self._screen = Xfw.Screen.get_default()
+        self._seat = None
+        seats = self._screen.get_seats()
+        if seats:
+            self._seat = seats[0]
+        if common.USED_UI_TYPE != "GTK":
+            self._mainloop = GLib.MainLoop()
+            self._mainloop_thread = threading.Thread(
+                target=self._mainloop.run,
+                daemon=True,
+                name="wlroots-glib-mainloop"
+            )
+            self._mainloop_thread.start()
+        logger.debug("WlrootsWindowInterface initialized")
+
+    def cancel(self):
+        if hasattr(self, '_mainloop') and self._mainloop.is_running():
+            self._mainloop.quit()
+
+    def get_window_info(self, window=None, traverse=True):
+        active = self._screen.get_active_window()
+        if active is None:
+            return WindowInfo(wm_title='', wm_class='')
+        class_ids = active.get_class_ids()
+        wm_class = class_ids[0] if class_ids else ''
+        return WindowInfo(wm_title=active.get_name() or '', wm_class=wm_class)
+
+    def get_window_title(self, window=None, traverse=True):
+        active = self._screen.get_active_window()
+        if active is None:
+            return ''
+        return active.get_name() or ''
+
+    def get_window_class(self, window=None, traverse=True):
+        active = self._screen.get_active_window()
+        if active is None:
+            return ''
+        class_ids = active.get_class_ids()
+        return class_ids[0] if class_ids else ''
+
+    def get_window_list(self):
+        result = []
+        active = self._screen.get_active_window()
+        self._window_map = {}
+        for w in self._screen.get_windows():
+            wid = id(w)
+            self._window_map[wid] = w
+            class_ids = w.get_class_ids()
+            wm_class = class_ids[0] if class_ids else ''
+            is_active = (active is not None and w == active)
+            ws = w.get_workspace()
+            result.append({
+                'wm_class': wm_class,
+                'wm_title': w.get_name() or '',
+                'focus': is_active,
+                'x': 0, 'y': 0, 'width': 0, 'height': 0,
+                'id': wid,
+                'pid': None,
+                'workspace': ws.get_number() if ws else None,
+                'desktop': ws.get_number() if ws else None,
+                'in_current_workspace': w.is_in_viewport(ws) if ws else True,
+            })
+        return result
+
+    def get_active_window(self):
+        active = self._screen.get_active_window()
+        if active is None:
+            return self._empty_window()
+        if not hasattr(self, '_window_map'):
+            self._window_map = {}
+        self._window_map[id(active)] = active
+        return self._window_to_dict(active, is_active=True)
+
+    def get_screen_size(self):
+        monitors = self._screen.get_monitors()
+        if not monitors:
+            return [0, 0]
+        max_x = max_y = 0
+        for mon in monitors:
+            geo = mon.get_logical_geometry()
+            max_x = max(max_x, geo.x + geo.width)
+            max_y = max(max_y, geo.y + geo.height)
+        return [max_x, max_y]
+
+    def get_active_desktop_index(self):
+        wm = self._screen.get_workspace_manager()
+        for ws in wm.list_workspaces():
+            if ws.get_state() & Xfw.WorkspaceState.ACTIVE:
+                return ws.get_number()
+        return 0
+
+    def close_window(self, window_id):
+        w = self._find_window(window_id)
+        if w:
+            w.close(0)
+
+    def activate_window(self, window_id):
+        w = self._find_window(window_id)
+        if w:
+            w.activate(self._seat, 0)
+
+    def move_resize_window(self, window_id, x, y, width, height):
+        w = self._find_window(window_id)
+        if w:
+            try:
+                from gi.repository import Gdk
+                rect = Gdk.Rectangle()
+                rect.x, rect.y, rect.width, rect.height = x, y, width, height
+                w.set_geometry(rect)
+            except Exception:
+                logger.warning("set_geometry not supported on this compositor")
+
+    def move_to_workspace(self, window_id, workspace_number):
+        w = self._find_window(window_id)
+        if w:
+            wm = self._screen.get_workspace_manager()
+            for ws in wm.list_workspaces():
+                if ws.get_number() == workspace_number:
+                    w.move_to_workspace(ws)
+                    return
+
+    def switch_workspace(self, workspace_number):
+        wm = self._screen.get_workspace_manager()
+        for ws in wm.list_workspaces():
+            if ws.get_number() == workspace_number:
+                ws.activate()
+                return
+
+    def get_properties(self, window_id):
+        w = self._find_window(window_id)
+        if w:
+            return self._window_to_dict(w, w.is_active())
+        return self._empty_window()
+
+    def stick_window(self, window_id):
+        w = self._find_window(window_id)
+        if w:
+            w.set_pinned(True)
+
+    def unstick_window(self, window_id):
+        w = self._find_window(window_id)
+        if w:
+            w.set_pinned(False)
+
+    def maximize_window(self, window_id, direction):
+        w = self._find_window(window_id)
+        if w:
+            w.set_maximized(True)
+
+    def unmaximize_window(self, window_id, direction):
+        w = self._find_window(window_id)
+        if w:
+            w.set_maximized(False)
+
+    def make_fullscreen_window(self, window_id):
+        w = self._find_window(window_id)
+        if w:
+            w.set_fullscreen(True)
+
+    def unmake_fullscreen_window(self, window_id):
+        w = self._find_window(window_id)
+        if w:
+            w.set_fullscreen(False)
+
+    def make_above_window(self, window_id):
+        w = self._find_window(window_id)
+        if w:
+            w.set_above(True)
+
+    def unmake_above_window(self, window_id):
+        w = self._find_window(window_id)
+        if w:
+            w.set_above(False)
+
+    def _find_window(self, window_id):
+        if hasattr(self, '_window_map') and window_id in self._window_map:
+            return self._window_map[window_id]
+        for w in self._screen.get_windows():
+            title = w.get_name() or ''
+            class_ids = w.get_class_ids()
+            wm_class = class_ids[0] if class_ids else ''
+            if str(window_id) in (title, wm_class):
+                return w
+        return None
+
+    def _window_to_dict(self, w, is_active):
+        class_ids = w.get_class_ids()
+        wm_class = class_ids[0] if class_ids else ''
+        ws = w.get_workspace()
+        return {
+            'wm_class': wm_class,
+            'wm_title': w.get_name() or '',
+            'focus': is_active,
+            'x': 0, 'y': 0, 'width': 0, 'height': 0,
+            'id': id(w),
+            'pid': None,
+            'workspace': ws.get_number() if ws else None,
+            'desktop': ws.get_number() if ws else None,
+            'in_current_workspace': True,
+            'is_maximized': w.is_maximized(),
+            'is_maximized_vert': w.is_maximized(),
+            'is_fullscreen': w.is_fullscreen(),
+            'is_above': w.is_above(),
+            'is_minimized': w.is_minimized(),
+            'is_pinned': w.is_pinned(),
+        }
+
+    @staticmethod
+    def _empty_window():
+        return {
+            'wm_class': '', 'wm_title': '', 'focus': False,
+            'x': 0, 'y': 0, 'width': 0, 'height': 0,
+            'id': None, 'pid': None, 'workspace': None,
+            'desktop': None, 'in_current_workspace': False,
+        }
+
+
+class SwayMouseInterface:
+
+    def __init__(self):
+        pass
+
+    def mouse_location(self):
+        try:
+            proc = subprocess.run(
+                ['swaymsg', '-t', 'get_seats', '--raw'],
+                capture_output=True, text=True, timeout=2
+            )
+            seats = json.loads(proc.stdout)
+            for seat in seats:
+                if seat.get('focus'):
+                    cursor = seat.get('cursor', {})
+                    return [int(cursor.get('x', 0)), int(cursor.get('y', 0))]
+            if seats:
+                cursor = seats[0].get('cursor', {})
+                return [int(cursor.get('x', 0)), int(cursor.get('y', 0))]
+        except Exception as e:
+            logger.error(f"Failed to get mouse location from swaymsg: {e}")
+        return [0, 0]
+
+
+class FallbackMouseInterface:
+
+    def __init__(self):
+        pass
+
+    def mouse_location(self):
+        raise NotImplementedError(
+            "Cursor position query is not available on this Wayland compositor. "
+            "This feature requires compositor-specific IPC (e.g. Sway)."
+        )


### PR DESCRIPTION
Adds Sway support on top of the wlroots infrastructure from Budgie support:
- `SwayMouseInterface` using `swaymsg -t get_seats` for cursor position
- SWAY desktop detection and routing
- Sway added to `WLROOTS_DESKTOPS` tuple

This PR contains only the Sway-specific changes. Depends on #51 (Budgie support) being merged first.

Fixes #46