### PR TITLE
[Bug] Hotkey stops working after repeated use

### DIFF
--- a/lib/autokey/uinput_interface.py
+++ b/lib/autokey/uinput_interface.py
@@ -819,17 +819,12 @@ class UInputInterface(threading.Thread, MouseReadInterface, AbstractSysInterface
                     #if event_type.
                     #self.handle_mouseclick(event)
 
-                # dlk3 - the following self.ui.write sends through AutoKey hotkeys,
-                # which it shouldn't do, so we'll return now, before that happens,
-                # if the "held" list holds an AutoKey hotkey
-                if self.__isAutoKeyHotkey(held):
-                    return
-
                 # dlk3 - support multiple keyboards/mice
-                # pass through to autokey uinput device
-                for keyboard in self.keyboards:
-                    if not self.sending and fd == keyboard.fd:
-                        self.ui.write(event.type, event.code, event.value)
+                # pass through to autokey uinput device, but not for AutoKey hotkeys
+                if not self.__isAutoKeyHotkey(held):
+                    for keyboard in self.keyboards:
+                        if not self.sending and fd == keyboard.fd:
+                            self.ui.write(event.type, event.code, event.value)
 
     #  @dlk3 - Does the list of keys from __flush_events() match an AutoKey hotkey?
     def __isAutoKeyHotkey(self, key_list):

--- a/lib/autokey/wayland_checks.py
+++ b/lib/autokey/wayland_checks.py
@@ -35,7 +35,7 @@ def waylandChecks():
 
     try:
         #  We only do this stuff when running under Wayland
-        if os.environ['XDG_SESSION_TYPE'] != "wayland":
+        if os.environ.get('XDG_SESSION_TYPE', '') != "wayland":
             return True
 
         #  Check that we're running on a supported desktop environment


### PR DESCRIPTION
## Summary
- Fix early `return` in `__flush_events()` that dropped modifier key-up events, causing hotkeys to stop working after a few activations
- Fix `KeyError` crash in `waylandChecks()` when `XDG_SESSION_TYPE` is unset (e.g. tmux)

## Test plan
- [ ] Configure a hotkey with modifiers (e.g. Ctrl+Super+A)
- [ ] Activate it repeatedly (10+ times) and verify it keeps working

Fixes #53

🤖 Generated with [Claude Code](https://claude.com/claude-code)